### PR TITLE
修复auth未配置，重连时候永远调用$redis->auth方法错误

### DIFF
--- a/src/RedisConnection.php
+++ b/src/RedisConnection.php
@@ -81,7 +81,7 @@ class RedisConnection extends BaseConnection implements ConnectionInterface
             throw new ConnectionException('Connection reconnect failed.');
         }
 
-        if (isset($auth)) {
+        if (isset($auth) && $auth) {
             $redis->auth($auth);
         }
 


### PR DESCRIPTION
如果.env文件没有配置REDIS_AUTH，$auth此时值为""，isset($auth)为true
